### PR TITLE
Upgrade CertificateSigningRequest to v1 API with well-known signer

### DIFF
--- a/create-user.sh
+++ b/create-user.sh
@@ -45,7 +45,7 @@ kubectl delete csr ${USER}-${TENANT} 2>/dev/null || true
 
 # Create a new CSR file.
 cat <<EOF > ${TMPDIR}/${USER}-${TENANT}-csr.yaml
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: ${USER}-${TENANT}
@@ -53,6 +53,7 @@ spec:
   groups:
   - system:authenticated
   request: $(cat ${TMPDIR}/${USER}-${TENANT}.csr | base64 | tr -d '\n')
+  signerName: kubernetes.io/kube-apiserver-client
   usages:
   - digital signature
   - key encipherment


### PR DESCRIPTION
The current script fails on current clusters due to deprecated API version usage.

https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/\#signers